### PR TITLE
Build OH with Yarn

### DIFF
--- a/buildserver/Dockerfile
+++ b/buildserver/Dockerfile
@@ -7,7 +7,6 @@ RUN wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN apt-get update
 RUN apt-get install -yqq nodejs yarn
 RUN pip install -U pip && pip install pipenv
-RUN npm i -g npm@^6
 RUN rm -rf /var/lib/apt/lists/*
 
 RUN wget https://www.openssl.org/source/openssl-1.0.2g.tar.gz -O - | tar -xzpip

--- a/buildserver/build.py
+++ b/buildserver/build.py
@@ -66,7 +66,7 @@ def run_oh_queue_build():
     sh("python", "-m", "venv", "env")
     sh("env/bin/pip", "freeze")
     sh("env/bin/pip", "install", "-r", "requirements.txt")
-    sh("npm", "install")
+    sh("yarn")
     sh("env/bin/python", "./manage.py", "build")
 
 


### PR DESCRIPTION
Looks like it never depended on NPM in the first place. Who needs lockfiles anyway /s