### PR TITLE
Support restricting golinks to enrolled students only

### DIFF
--- a/common/course_config.py
+++ b/common/course_config.py
@@ -29,7 +29,7 @@ def get_domain():
 
 def get_endpoint(course=None):
     if getenv("ENV") != "prod":
-        return "cal/cs61a/fa20"
+        return "cal/cs61a/sp21"
     if not course:
         course = get_course()
     if course not in COURSE_ENDPOINTS:

--- a/common/oauth_client.py
+++ b/common/oauth_client.py
@@ -12,7 +12,7 @@ from common.rpc.auth import get_endpoint
 from common.rpc.secrets import get_secret
 from common.url_for import get_host, url_for
 
-AUTHORIZED_ROLES = ["staff", "instructor", "grader"]
+AUTHORIZED_ROLES = ("staff", "instructor", "grader")
 
 REDIRECT_KEY = "REDIRECT_KEY"
 
@@ -27,10 +27,14 @@ def is_logged_in():
 
 
 def is_staff(course):
+    return is_enrolled(course, roles=AUTHORIZED_ROLES)
+
+
+def is_enrolled(course, *, roles=None):
     try:
         endpoint = get_endpoint(course=course)
         for participation in get_user()["participations"]:
-            if participation["role"] not in AUTHORIZED_ROLES:
+            if roles and participation["role"] not in roles:
                 continue
             if participation["course"]["offering"] != endpoint and endpoint is not None:
                 continue

--- a/shortlinks/main.py
+++ b/shortlinks/main.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from flask import Flask, redirect, request
 
 import urllib.parse as urlparse
@@ -5,9 +7,15 @@ import urllib.parse as urlparse
 from common.course_config import get_course
 from common.db import connect_db
 from common.html import error, html, make_row
-from common.oauth_client import create_oauth_client, is_staff, login
+from common.oauth_client import create_oauth_client, is_enrolled, is_staff, login
 from common.rpc.auth import read_spreadsheet
 from common.url_for import url_for
+
+
+class AccessRestriction(Enum):
+    ALL = 0
+    STAFF = 1
+    STUDENT = 2
 
 
 with connect_db() as db:
@@ -16,7 +24,7 @@ with connect_db() as db:
     shortlink varchar(512),
     url varchar(512),
     creator varchar(512),
-    secure boolean,
+    secure int,
     course varchar(128)
 )"""
     )
@@ -25,7 +33,7 @@ with connect_db() as db:
         """CREATE TABLE IF NOT EXISTS sources (
     url varchar(512),
     sheet varchar(256),
-    secure boolean,
+    secure int,
     course varchar(128)
 )"""
     )
@@ -52,7 +60,21 @@ def lookup(path):
             "SELECT url, creator, secure FROM shortlinks WHERE shortlink=%s AND course=%s",
             [path, get_course()],
         ).fetchone()
-    return list(target) if target else (None, None, None)
+        if target:
+            target = list(target)
+            target[2] = AccessRestriction(target[2])
+    return target or (None, None, None)
+
+
+def is_authorized(secure: AccessRestriction):
+    if secure == AccessRestriction.ALL:
+        return True
+    elif secure == AccessRestriction.STAFF:
+        return is_staff(get_course())
+    elif secure == AccessRestriction.STUDENT:
+        return is_enrolled(get_course())
+    else:
+        raise Exception(f"{secure} is not a valid AccessRestriction")
 
 
 @app.route("/<path>/")
@@ -60,7 +82,7 @@ def handler(path):
     url, creator, secure = lookup(path)
     if not url:
         return error("Target not found!")
-    if secure and not is_staff(get_course()):
+    if not is_authorized(secure):
         return login()
     return redirect(add_url_params(url, request.query_string.decode("utf-8")))
 
@@ -70,7 +92,7 @@ def preview(path):
     url, creator, secure = lookup(path)
     if url is None:
         return html("No such link exists.")
-    if secure and not is_staff(get_course()):
+    if not is_authorized(secure):
         return login()
     return html(
         'Points to <a href="{0}">{0}</a> by {1}'.format(
@@ -88,16 +110,17 @@ def index():
             "SELECT url, sheet, secure FROM sources WHERE course=%s", [get_course()]
         ).fetchall()
 
-    insert_fields = """<input placeholder="Spreadsheet URL" name="url"></input>
+    insert_fields = f"""<input placeholder="Spreadsheet URL" name="url"></input>
         <input placeholder="Sheet Name" name="sheet"></input>
-        <label>
-            <input type="checkbox" name="secure"></input>
-            Require Authentication
-        </label>"""
+        <select name="secure">
+            <option value="{AccessRestriction.ALL.value}">Public</option>
+            <option value="{AccessRestriction.STAFF.value}">Staff Only</option>
+            <option value="{AccessRestriction.STUDENT.value}">Students and Staff</option>
+        </select>"""
 
     sources = "<br/>".join(
         make_row(
-            f'<a href="{url}">{url}</a> {sheet} (Secure: {secure})'
+            f'<a href="{url}">{url}</a> {sheet} (Secure: {AccessRestriction(secure).name})'
             f'<input name="url" type="hidden" value="{url}"></input>'
             f'<input name="sheet" type="hidden" value="{sheet}"></input>',
             url_for("remove_source"),
@@ -131,7 +154,7 @@ def add_source():
 
     url = request.form["url"]
     sheet = request.form["sheet"]
-    secure = True if request.form.get("secure", False) else False
+    secure = int(request.form.get("secure"))
 
     with connect_db() as db:
         db(


### PR DESCRIPTION
Changes `secure` from a bool to an int field, taking on three values: `ALL`, `STAFF`, `STUDENT`. The db migration can be run safely because the prod version only cares about the truthiness of `secure`, so `STUDENT` will behave as `STAFF` until we merge this PR.

Also complains about duplicate shortlinks, and I updated the sheets to remove the existing dupes.

- [x] DB migration run on prod

Testing:
![image](https://user-images.githubusercontent.com/18374604/104468619-815b3800-556c-11eb-9c58-14847d1303e4.png)

Verified that while signed out, go/meeting-notes is unaccessible, as is go/test, but go/textbook works. While signed in as staff, all three work. While signed in using a test student account, go/test and go/textbook both work. When the test student account is unenrolled from OKPy, go/test stops working. Verified also that go/meeting-notes and go/test are inaccessible on prod from a test student account, so the migration didn't break anything.