### PR TITLE
Resolve dependencies through symlinks

### DIFF
--- a/buildtool/buildtool/loader.py
+++ b/buildtool/buildtool/loader.py
@@ -175,7 +175,9 @@ def make_callback(
         ]
 
         make_callback.find_cache[target] = out = [
-            "//" + path for path in out if path in src_files
+            "//" + path
+            for path in out
+            if os.path.relpath(os.path.realpath(path), repo_root) in src_files
         ]
 
         return sorted(out)


### PR DESCRIPTION
This lets us depend on files through symlinks. For instance, we have an `//src/assets/slides` symlink, that points to `//src/slides/sp21/slides/published`. This lets us depend on `//src/assets/slides/Lecture01.pdf` and have the buildsystem (a) use the hash of the file in the `published` directory as part of the CacheKey, but (b) still load the file into `//src/assets/slides/Lecture01.pdf` in scratch directories, rather than loading it into the scratch directory based on its real location.

This does *not* let you output built files into symlinks / symlinked directories or anything like that, it only lets you _depend_ on files through symlinks.

After landing this PR, we must

- [ ] Redeploy IDE
- [ ] Redeploy buildserver
- [ ] Bump the minimum `bt` version in the repo for PRs using this commit (pr/3830 and pr/3827, at the moment)