### PR TITLE
Add doctest button

### DIFF
--- a/code/package.json
+++ b/code/package.json
@@ -27,6 +27,7 @@
     "babel-eslint": "^10.1.0",
     "eslint-config-prettier": "^7.1.0",
     "firebase": "^8.2.1",
+    "prettier": "^2.2.1",
     "source-map-support": "^0.5.10"
   },
   "devDependencies": {

--- a/code/src/languages/python/web/web_console.py
+++ b/code/src/languages/python/web/web_console.py
@@ -169,9 +169,7 @@ def json_repr(elem):
             elem_reprs.append(y)
         return "[" + ", ".join(elem_reprs) + "]"
     elif isinstance(elem, str):
-        # fmt off
         return repr(elem)
-        # fmt on
     elif isinstance(elem, dict):
         key_val_reprs = [
             json_repr(key) + ": " + json_repr(val) for key, val in elem.items()

--- a/code/src/languages/python/web/web_console.py
+++ b/code/src/languages/python/web/web_console.py
@@ -614,7 +614,7 @@ def run_doctests(f, *, export_json=False):
 
         if success:
             log_print(
-                f"All {len(block['cases'])} doctests for {f.__name__} > {block['name']} passed!"
+                f"All {len(block['cases'])} tests for {f.__name__} > {block['name']} passed!"
             )
 
         export.append(

--- a/code/src/languages/python/web/web_console.py
+++ b/code/src/languages/python/web/web_console.py
@@ -481,20 +481,43 @@ def indent(s, pad=4):
     return "\n".join(" " * pad + line for line in s.split("\n"))
 
 
-def run_doctests(f):
-    s = f.__doc__
-    if not s:
-        print(f"No doctests found for {f.__name__}, skipping...")
-        return
+def run_all_doctests():
+    export = []
+    done = set()
+    for obj in editor_ns.values():
+        if hasattr(obj, "__doc__") and hasattr(obj, "__name__"):
+            try:
+                if obj in done:
+                    continue
+                done.add(obj)
+            except TypeError:
+                # maybe obj is unhashable? But it might be callable, so try it anyway
+                pass
+            out = run_doctests(obj, export_json=True)
+            if out:
+                export.extend(out)
+    print("DOCTEST: " + json_repr(export))
+
+
+def run_doctests(f, *, export_json=False):
+    s = f.__doc__ or ""
 
     tests = []
+    curr_block = dict(name="Doctests", cases=[])
     curr_case = None
     for i, line in enumerate(s.strip().split("\n")):
         line = line.strip()
-        if line.startswith(">>> "):
+        if line.startswith("# "):
+            if curr_case is not None:
+                curr_block["cases"].append(curr_case)
+            if curr_block["cases"]:
+                tests.append(curr_block)
+            curr_block = dict(name=line[2:].strip(), cases=[])
+            curr_case = None
+        elif line.startswith(">>> "):
             # new test case
             if curr_case is not None:
-                tests.append(curr_case)
+                curr_block["cases"].append(curr_case)
             curr_case = [line[4:], ""]
         elif line.startswith("... "):
             # continue previous test case
@@ -503,7 +526,7 @@ def run_doctests(f):
             curr_case[0] += "\n" + line[4:]
         else:
             if not line and curr_case is not None:
-                tests.append(curr_case)
+                curr_block["cases"].append(curr_case)
                 curr_case = None
             if curr_case is not None:
                 if curr_case[1]:
@@ -511,54 +534,101 @@ def run_doctests(f):
                 curr_case[1] += line
 
     if curr_case is not None:
-        tests.append(curr_case)
+        curr_block["cases"].append(curr_case)
+    if curr_block["cases"]:
+        tests.append(curr_block)
+
+    if not tests:
+        if not export_json:
+            print(f"No doctests found for {f.__name__}, skipping...")
+        return
+
+    if len(tests) > 1 and tests[0]["name"] == "Doctests":
+        tests[0]["name"] = "Setup"
 
     namespace = dict(editor_ns)
 
-    print(f"Running {len(tests)} doctests for {f.__name__}:")
-
-    for i, (inp, exp) in enumerate(tests):
-        out = []
-        old_write = sys.stdout.write
-        old_err = sys.stderr.write
-        try:
-            sys.stdout.write = sys.stderr.write = out.append
-            try:
-                ret = eval(inp, namespace)
-                if ret is not None:
-                    print(ret)
-            except SyntaxError as msg:
-                if str(msg) == "eval() argument must be an expression":
-                    out[:] = []
-                    exec(inp, namespace)
-                else:
-                    raise
-        except Exception:
-            print_tb()
-        finally:
-            sys.stdout.write = old_write
-            sys.stderr.write = old_err
-        out = "".join(out)
-        first, *rest = inp.split("\n")
-        if out.strip() != exp.strip():
-            err("Failed example:\n")
-            err(indent(f">>> {first}") + "\n")
-            for r in rest:
-                err(indent(f"... {r}") + "\n")
-            err(f"Expected:\n")
-            err(indent(exp.strip()) + "\n")
-            err("Received:\n")
-            err(indent(out.strip()) + "\n")
-            err(f"{i} out of {len(tests)} tests passed.\n")
-            return
+    export = []
+    executed = []
+    for block in tests:
+        all_out = []
+        if export_json:
+            log_print = lambda x: all_out.append(x + "\n")
+            log_err = all_out.append
+            pad = 0
         else:
-            print(indent(f">>> {first}"))
-            for r in rest:
-                print(indent(f"... {r}"))
-            if out.strip():
-                print(indent(out.strip()))
+            log_print = print
+            log_err = err
+            pad = 4
 
-    print(f"All {len(tests)} doctests for {f.__name__} passed!")
+        log_print(
+            f"Running {len(block['cases'])} tests in {f.__name__} > {block['name']}:"
+        )
+
+        success = True
+
+        for i, (inp, exp) in enumerate(block["cases"]):
+            out = []
+            old_write = sys.stdout.write
+            old_err = sys.stderr.write
+            try:
+                executed.append(inp)
+                sys.stdout.write = sys.stderr.write = out.append
+                try:
+                    ret = eval(inp, namespace)
+                    if ret is not None:
+                        print(ret)
+                except SyntaxError as msg:
+                    if str(msg) == "eval() argument must be an expression":
+                        out[:] = []
+                        exec(inp, namespace)
+                    else:
+                        raise
+            except Exception:
+                print_tb()
+            finally:
+                sys.stdout.write = old_write
+                sys.stderr.write = old_err
+            out = "".join(out)
+            first, *rest = inp.split("\n")
+            success = out.strip() == exp.strip()
+            if not success:
+                log_err("Failed example:\n")
+                log_err(indent(f">>> {first}") + "\n")
+                for r in rest:
+                    log_err(indent(f"... {r}") + "\n")
+                log_err(f"Expected:\n")
+                log_err(indent(exp.strip()) + "\n")
+                log_err("Received:\n")
+                log_err(indent(out.strip()) + "\n")
+                log_err(
+                    f"{i} out of {len(block['cases'])} tests passed in {block['name']}.\n"
+                )
+                break
+            else:
+                log_print(indent(f">>> {first}", pad=pad))
+                for r in rest:
+                    log_print(indent(f"... {r}", pad=pad))
+                if out.strip():
+                    log_print(indent(out.strip(), pad=pad))
+
+        if success:
+            log_print(
+                f"All {len(block['cases'])} doctests for {f.__name__} > {block['name']} passed!"
+            )
+
+        export.append(
+            dict(
+                name=[f"Doctests for {f.__name__}", block["name"]],
+                rawName=f"{f.__name__} > {block['name']}",
+                success=success,
+                code=["\n".join(executed)],
+                raw="".join(all_out),
+            )
+        )
+
+    if export_json:
+        return export
 
 
 editor_ns = {
@@ -582,6 +652,7 @@ editor_ns = {
     "label": label,
     "branches": branches,
     "test": run_doctests,
+    "__run_all_doctests": run_all_doctests,
 }
 
 replace_trees(editor_ns)
@@ -606,7 +677,6 @@ def handleInput(line):
         else:
             write(_launchtext)
             err("\n>>> ")
-            # doc['code'].value += 'Type "copyright", "credits" or "license" for more information.'
         firstLine = False
         return
 

--- a/code/src/renderer/components/CommandIcon.js
+++ b/code/src/renderer/components/CommandIcon.js
@@ -17,7 +17,7 @@ export default function CommandIcon(props) {
 function computeIcon(name) {
   return {
     Run: { color: "green", className: "fas fa-play" },
-    Test: { color: "red", className: "fas fa-graduation-cap" },
+    Test: { color: "red", className: "fas fa-vial" },
     Debug: { color: "orange", className: "fas fa-bug" },
     Stop: { color: "red", className: "fas fa-stop" },
     Restart: { color: "green", className: "fas fa-redo" },

--- a/code/src/renderer/components/File.js
+++ b/code/src/renderer/components/File.js
@@ -150,7 +150,8 @@ export default class File extends React.Component {
           return;
         }
         const rawData = out.slice(DOCTEST_MARKER.length);
-        const doctestData = JSON.parse(rawData);
+        // eslint-disable-next-line no-eval
+        const doctestData = (0, eval)(rawData);
         this.setState({ doctestData });
         this.testRef.current.forceOpen();
         killCallback();

--- a/code/src/renderer/components/File.js
+++ b/code/src/renderer/components/File.js
@@ -349,9 +349,9 @@ export default class File extends React.Component {
   handleEditorChange = (editorText) => {
     if (this.props.srcOrigin) {
       /*
-              It is not possible to exfiltrate data, since srcOrigin is only set when the caller
-              *also* is supplying the _contents_ of the file, so there's no data to steal!
-               */
+      It is not possible to exfiltrate data, since srcOrigin is only set when the caller
+      *also* is supplying the _contents_ of the file, so there's no data to steal!
+       */
       window.parent.postMessage(
         { fileName: this.props.initFile.name, data: editorText },
         this.props.srcOrigin

--- a/code/src/renderer/components/MainScreen.js
+++ b/code/src/renderer/components/MainScreen.js
@@ -14,12 +14,9 @@ import {
   SHOW_OPEN_DIALOG,
 } from "../../common/communicationEnums.js";
 import NavBar from "./NavBar";
-import OKResults from "./OKResults";
 import { initGoldenLayout } from "../utils/goldenLayout";
-import registerOKPyHandler from "../utils/receiveOKResults";
 import claimMenu from "../utils/menuHandler";
 import File from "./File";
-import generateDebugTrace from "../../languages/python/utils/generateDebugTrace.js";
 import { sendNoInteract } from "../utils/communication.js";
 import Console from "./Console.js";
 import { openHelp } from "../utils/help.js";
@@ -33,11 +30,6 @@ export default class MainScreen extends React.Component {
       activeFileKey: null,
 
       consoles: [],
-
-      okResults: null,
-      cachedOKModules: {},
-      okPath: null,
-      detachOKPyCallback: registerOKPyHandler(this.handleOKPyUpdate),
 
       detachMenuCallback: claimMenu({
         [MENU_NEW]: this.newFile,
@@ -73,7 +65,6 @@ export default class MainScreen extends React.Component {
   }
 
   componentWillUnmount() {
-    this.state.detachOKPyCallback();
     this.state.detachMenuCallback();
   }
 
@@ -136,39 +127,6 @@ export default class MainScreen extends React.Component {
     this.setState((state) => ({ consoles: state.consoles.concat([0]) }));
   };
 
-  handleOKPyUpdate = (okResults, cachedOKModules, okPath) => {
-    this.setState({ okResults, cachedOKModules, okPath });
-    this.okResultsRef.current.forceOpen();
-  };
-
-  handleOKPyDebug = async (testData) => {
-    const setupCode = [];
-    const caseCode = [];
-    let i = 0;
-    for (; i !== testData.code.length; ++i) {
-      if (!testData.code[i].includes("import")) {
-        break;
-      }
-      setupCode.push(testData.code[i]);
-    }
-    for (; i !== testData.code.length; ++i) {
-      caseCode.push(testData.code[i]);
-    }
-
-    const setupCodeStr = setupCode.join("\n");
-    const caseCodeStr = caseCode.join("\n");
-
-    // todo: make language agnostic
-    const debugData = await generateDebugTrace(
-      caseCodeStr,
-      this.state.cachedOKModules,
-      setupCodeStr,
-      this.state.okPath
-    );
-
-    this.state.files[this.state.activeFileKey].ref.current.debug(debugData);
-  };
-
   handleFileActivate = (key) => {
     if (key !== this.state.activeFileKey) {
       this.setState({
@@ -218,12 +176,6 @@ export default class MainScreen extends React.Component {
         {fileElems}
         {consoleElems}
         <div id="tabRoot" />
-        <OKResults
-          ref={this.okResultsRef}
-          title="OKPy Results"
-          onDebug={this.handleOKPyDebug}
-          data={this.state.okResults}
-        />
       </>
     );
   }

--- a/code/src/renderer/components/NavBarIcons.js
+++ b/code/src/renderer/components/NavBarIcons.js
@@ -2,7 +2,7 @@ import React from "react";
 import NavBarIcon from "./NavBarIcon";
 
 export default function NavBarIcons(props) {
-  const actions = ["Format", "Debug", "Run"];
+  const actions = ["Format", "Debug", "Test", "Run"];
   const icons = actions.map((action) => (
     <NavBarIcon
       key={action}

--- a/code/src/renderer/components/OKResults.js
+++ b/code/src/renderer/components/OKResults.js
@@ -117,6 +117,7 @@ class OKResults extends React.Component {
           selectedProblemData.success =
             selectedProblemData.success && elem.success;
         }
+        selectedProblemData.code = elem.code;
       }
       selectedProblemData.raw = selectedProblemData.raw.join(
         `\n${"-".repeat(69)}\n`

--- a/code/src/renderer/components/OutputElem.js
+++ b/code/src/renderer/components/OutputElem.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-eval */
 import * as React from "react";
 import StdoutElem from "./StdoutElem.js";
 import OutputDrawElem from "./OutputDrawElem.js";
@@ -10,7 +11,7 @@ export default function OutputElem(props) {
     try {
       return (
         <OutputDrawElem
-          data={JSON.parse(props.text.substr(DRAW_MARKER.length))}
+          data={(0, eval)(props.text.substr(DRAW_MARKER.length))}
         />
       );
     } catch (e) {

--- a/code/src/renderer/components/TestElem.js
+++ b/code/src/renderer/components/TestElem.js
@@ -8,7 +8,7 @@ export default class TestElem extends React.Component {
   }
 
   componentDidMount() {
-    this.divRef.current.scrollIntoViewIfNeeded();
+    this.divRef.current.scrollIntoView();
   }
 
   handleClick = () => {

--- a/code/src/renderer/style.global.css
+++ b/code/src/renderer/style.global.css
@@ -106,6 +106,8 @@ html {
     width: calc(100% - 20px);
     bottom: 20px;
     height: calc(100% - 90px);
+    white-space: pre-wrap;
+    font-family: 'Consolas', 'Monaco', monospace;
 }
 
 .modalCol {

--- a/code/webpack.web.config.js
+++ b/code/webpack.web.config.js
@@ -79,7 +79,7 @@ module.exports = (env) => ({
       ELECTRON: false,
       SCHEME_COMPILE: (env && env.SCHEME_COMPILE) || false,
       __static: JSON.stringify("/static"),
-      VERSION: '"2.0.13"',
+      VERSION: '"2.1.0"',
     }),
     new MonacoWebpackPlugin({
       output: "./static",

--- a/code/yarn.lock
+++ b/code/yarn.lock
@@ -8711,6 +8711,11 @@ prepend-http@^1.0.0, prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+
 pretty-bytes@^5.1.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.5.0.tgz#0cecda50a74a941589498011cf23275aa82b339e"


### PR DESCRIPTION
Adds a button in the navbar to run doctests:
![image](https://user-images.githubusercontent.com/18374604/106734956-7f632280-65c8-11eb-9995-810951ac0d78.png)

Only Python is supported for now.

Doctests appear in a dedicated pane at the bottom:
![image](https://user-images.githubusercontent.com/18374604/106735008-8ab64e00-65c8-11eb-8f6a-3537ec65b8dc.png)

If the system cannot even run the doctests (e.g. because of a syntax or internal error), an error message is displayed:
![image](https://user-images.githubusercontent.com/18374604/106735226-d10bad00-65c8-11eb-9194-d61d4fd2e0b6.png)


Doctests can be broken up into "cases" that are run in batches, using syntax as follows:
```
def chain_function():
    """
    # Setup (any line prefixed with a # creates a new case)
    >>> tester = chain_function()

    # Case 1
    >>> x = tester(1)(2)(4)(5) # Expected 3 but got 4, so print 3. 1st chain break, so print 1 too.
    3 1

    # Case 2
    >>> y = tester(4)(5)(8) # New chain, starting at 4, break at 6, first chain break
    6 1
    """
```
If one case fails, the runner continues to run the next cases anyway, and displays all the results to the user.

The "Debug" icon in the doctest panel opens an environment diagram that runs the entire program + the relevant tests. 