### PR TITLE
Fix buildtool dynamic dependency resolution bug

### DIFF
--- a/buildtool/buildtool/context.py
+++ b/buildtool/buildtool/context.py
@@ -74,6 +74,7 @@ class MemorizeContext(Context):
         super().__init__(repo_root, cwd)
         self.hashstate = hashstate
         self.inputs = []
+        self.uses_dynamic_inputs = False
         self.hashstate.record(self.absolute(self.cwd))
 
     def chdir(self, dest: str):
@@ -92,6 +93,7 @@ class MemorizeContext(Context):
                 self.inputs.append(self.absolute(dep))
 
     def input(self, *, file: Optional[str], sh: Optional[str], env: Env = None):
+        self.uses_dynamic_inputs = True
         self.hashstate.record("input", file, sh, env)
         if file is not None:
             self.inputs.append(self.absolute(file))

--- a/buildtool/buildtool/preview_execution.py
+++ b/buildtool/buildtool/preview_execution.py
@@ -143,5 +143,6 @@ def get_deps(build_state: BuildState, rule: Rule):
         return (
             hashstate.state() if ok else None,
             ctx.inputs + rule.deps,
+            ctx.uses_dynamic_inputs,
         )
-    return None, rule.deps
+    return None, rule.deps, None


### PR DESCRIPTION
Explanation for the bug and how the fix works:

Imagine we have a build rule that looks like (psuedocode)
```
def rule():
    depend_on(A) # static dependency
    deps = make_dependencies(A) # returns [B, C]
    depend_on(deps)
    do_build()
```

The output of `make_dependencies()` is cached based on the value of `A`, and the output of `do_build()` is cached based on the values of `[A, *deps] = [A, B, C]`.

Imagine that we change the value of file `A`. Then the build system will stop at `make_dependencies`, realize that the cache for `make_dependencies(A)` is missing so it doesn't know what `deps` is, and return `cache_key = None`. Then, it will rerun `make_dependencies` in the repo directory to determine `deps`, copy `[A, *deps]` into a scratch directory, and then run `do_build()` in the scratch directory. This is all correct.

However, now imagine that we change the value of file `B` in such a way that `A` now depends on `[B, C, D]`. The build system will use the cached value of `make_dependencies` to compute a cache key based on `[B, C]`. Since `B` has changed, this cache key has changed as well, as expected. So it will rerun `do_build`. **However, since the cache key is not `None`, it reruns `do_build()` in a scratch directory with just `[B, C]` available**, not including `D`. This is a bug!

This bug comes from how we handle dynamic dependencies. There are fundamentally two types of build rules in the system. Rules that have purely static dependencies, and rules that may have dynamic dependencies (that use `ctx.input()`). For rules with dynamic dependencies, we rely on the following invariant: that at the end, every file the rule depends on is passed into `ctx.add_deps` _at some point_, potentially after the command that depends on the file is run. So during `PreviewExecution`, the output of `ctx.inputs()` is _suspect_ -- it is only accurate if, at the end, the final `cache_key` is present within our cache. So we need to rerun the build rule _in the repo directory_, not in a scratch directory, in order to recompute the dynamic dependencies.