### PR TITLE
code/fix syntax error handling

### DIFF
--- a/code/src/languages/python/web/web_console.py
+++ b/code/src/languages/python/web/web_console.py
@@ -122,15 +122,6 @@ def print_tb():
     err(trace.format())
 
 
-def syntax_error(args):
-    info, filename, lineno, offset, line = args
-    print(f"  File {filename}, line {lineno}")
-    print("    " + line)
-    print("    " + offset * " " + "^")
-    print("SyntaxError:", info)
-    flush()
-
-
 OUT_BUFFER = ""
 src = ""
 
@@ -742,7 +733,7 @@ def handleInput(line):
                 err("... ")
                 _status = "block"
             else:
-                syntax_error(msg.args)
+                print_tb()
                 err(">>> ")
                 _status = "main"
         except Exception as e:

--- a/code/webpack.web.config.js
+++ b/code/webpack.web.config.js
@@ -79,7 +79,7 @@ module.exports = (env) => ({
       ELECTRON: false,
       SCHEME_COMPILE: (env && env.SCHEME_COMPILE) || false,
       __static: JSON.stringify("/static"),
-      VERSION: '"2.2.0"',
+      VERSION: '"2.2.1"',
     }),
     new MonacoWebpackPlugin({
       output: "./static",


### PR DESCRIPTION
A bug was introduced because of a change in Brython (https://github.com/brython-dev/brython/commit/0c37886566214bc1393d6fea540fc1b72b13f62e).

I don't understand why we even need special handling of syntaxerrors (I originally copied it from Brython's web_console), so we might as well just let Brython handle their reprs.