### PR TITLE
Added multithreading to improve pandoc processing speed

### DIFF
--- a/examtool/examtool/cli/compile.py
+++ b/examtool/examtool/cli/compile.py
@@ -72,6 +72,12 @@ from examtool.cli.utils import (
     help="Generates a draft copy of the exam, which is faster but less accurate.",
 )
 @click.option(
+    "--num-threads",
+    default=16,
+    type=int,
+    help="The number of threads to process the JSON file.",
+)
+@click.option(
     "--require-explicit-ids",
     default=False,
     is_flag=True,
@@ -90,6 +96,7 @@ def compile(
     json_out,
     merged_md,
     draft,
+    num_threads,
     require_explicit_ids,
     out,
 ):
@@ -118,6 +125,7 @@ def compile(
             src,
             path=path,
             draft=draft,
+            num_threads=num_threads,
             allow_random_ids=not require_explicit_ids,
         )
     else:


### PR DESCRIPTION
I am not as aware of how pandoc works though this seemed to not give me a different json output file so it seems like it is stable. I also made it so you can set the thread count to 1 which would be the same as it originally is. Seems to massively improve exam creation time. An exam which took a minute and 15 seconds went down to a 12 second process (It processed 852 items).

I have tested it on another exam we have had (the one we gave over summer) and when I seed the random function, I get the exact same exam md5 hash of the json file so it looks like it does not affect it.