### PR TITLE
fix: consolidate OH library CDNs

### DIFF
--- a/oh/oh_queue/templates/default.html
+++ b/oh/oh_queue/templates/default.html
@@ -23,7 +23,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css"
     />
 
     {{ macros.css_asset('style.css') }}
@@ -85,7 +85,7 @@
     ></script>
     <script
       type="text/javascript"
-      src="https://gitcdn.github.io/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"
+      src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"
     ></script>
     <script
       type="text/javascript"
@@ -93,10 +93,10 @@
     ></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/sweetalert2@9/dist/sweetalert2.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/limonte-sweetalert2/9.17.2/sweetalert2.min.css"
       id="theme-styles"
     />
-    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@9/dist/sweetalert2.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/limonte-sweetalert2/9.17.2/sweetalert2.min.js"></script>
 
     <!-- App-specific JS -->
     {{ macros.js_asset('common.js') }}


### PR DESCRIPTION
`gitcdn.github.io` seems to have connection issues, particularly in areas where GitHub has history of being blocked.

Might as well pull everything from the same CDN and take advantage of connection reuse.

From a brief test, the old and new URLs have identical contents, so there shouldn't be any breakage.