### PR TITLE
Improved error messages when using imported files.

### DIFF
--- a/exam-write/README.md
+++ b/exam-write/README.md
@@ -92,7 +92,15 @@ Each question block is introduced with
 
 Note that, unlike groups, questions do not have titles. Then you can provide some question
 body text, written in Markdown. Then you must provide at least one `INPUT` statement. Then
-you can provide `SOLUTION` and `NOTE` blocks. Then a question is ended with
+you can provide `SOLUTION` and `NOTE` blocks. 
+
+Additionally, you can set a constant ID for your question by setting the config ID such as
+
+```
+# CONFIG ID MYNEWID
+```
+
+Then a question is ended with
 
 ```
 # END QUESTION

--- a/exam-write/README.md
+++ b/exam-write/README.md
@@ -94,7 +94,7 @@ Note that, unlike groups, questions do not have titles. Then you can provide som
 body text, written in Markdown. Then you must provide at least one `INPUT` statement. Then
 you can provide `SOLUTION` and `NOTE` blocks. 
 
-Additionally, you can set a constant ID for your question by setting the config ID such as
+Additionally, you can set a constant ID for your question by setting the config ID.
 
 ```
 # CONFIG ID MYNEWID

--- a/examtool/examtool/api/convert.py
+++ b/examtool/examtool/api/convert.py
@@ -372,7 +372,7 @@ def consume_rest_of_group(buff, end, idfactory):
             raise SyntaxError(f"Unexpected directive ({line}) in GROUP")
 
 
-def _convert(text, *, path=None):
+def _convert(text, *, path=None, allow_random_ids=True):
     buff = LineBuffer(text)
     groups = []
     public = None
@@ -380,7 +380,7 @@ def _convert(text, *, path=None):
     substitutions = {}
     substitutions_match = []
     substitution_groups = []
-    idfactory = IDFactory()
+    idfactory = IDFactory(allow_random_ids=allow_random_ids)
     try:
         if path is not None:
             handle_imports(buff, path)
@@ -487,12 +487,12 @@ def pandoc(target, *, draft=False):
     return json.dumps(target, default=pandoc_dump)
 
 
-def convert(text, *, path=None, draft=False):
-    return json.loads(convert_str(text, path=path, draft=draft))
+def convert(text, *, path=None, draft=False, allow_random_ids=True):
+    return json.loads(convert_str(text, path=path, draft=draft, allow_random_ids=allow_random_ids))
 
 
-def convert_str(text, *, path=None, draft=False):
-    return pandoc(_convert(text, path=path), draft=draft)
+def convert_str(text, *, path=None, draft=False, allow_random_ids=True):
+    return pandoc(_convert(text, path=path, allow_random_ids=allow_random_ids), draft=draft)
 
 
 def import_file(filepath: str) -> str:

--- a/examtool/examtool/api/convert.py
+++ b/examtool/examtool/api/convert.py
@@ -387,7 +387,9 @@ def _convert(text, *, path=None, mainfilepath=None, allow_random_ids=True):
     substitutions_match = []
     substitution_groups = []
     idfactory = IDFactory(allow_random_ids=allow_random_ids)
-    importfactory = ImportFactory().handle_imports(buff, path, parentfilepath=mainfilepath)
+    importfactory = ImportFactory().handle_imports(
+        buff, path, parentfilepath=mainfilepath
+    )
     try:
         while not buff.empty():
             line = buff.pop()
@@ -505,7 +507,15 @@ def pandoc(target, *, draft=False, threadcount=16):
     return json.dumps(target, default=pandoc_dump)
 
 
-def convert(text, *, path=None, draft=False, mainfilepath=None, allow_random_ids=True, threadcount=None):
+def convert(
+    text,
+    *,
+    path=None,
+    draft=False,
+    mainfilepath=None,
+    allow_random_ids=True,
+    threadcount=None,
+):
     return json.loads(
         convert_str(
             text,
@@ -519,10 +529,21 @@ def convert(text, *, path=None, draft=False, mainfilepath=None, allow_random_ids
 
 
 def convert_str(
-    text, *, path=None, draft=False, mainfilepath=None, allow_random_ids=True, threadcount=None
+    text,
+    *,
+    path=None,
+    draft=False,
+    mainfilepath=None,
+    allow_random_ids=True,
+    threadcount=None,
 ):
     return pandoc(
-        _convert(text, path=path, mainfilepath=mainfilepath, allow_random_ids=allow_random_ids),
+        _convert(
+            text,
+            path=path,
+            mainfilepath=mainfilepath,
+            allow_random_ids=allow_random_ids,
+        ),
         draft=draft,
         threadcount=threadcount,
     )

--- a/examtool/examtool/api/convert.py
+++ b/examtool/examtool/api/convert.py
@@ -13,6 +13,7 @@ VERSION = 2  # increment when backward-incompatible changes are made
 html_convert = lambda x: pypandoc.convert_text(x, "html5", "md", ["--mathjax"])
 tex_convert = lambda x: pypandoc.convert_text(x, "latex", "md")
 
+exam_ids = set()
 
 class LineBuffer:
     def __init__(self, text):
@@ -263,9 +264,20 @@ def consume_rest_of_question(buff):
 
                 if option_solutions and solution:
                     raise SyntaxError("Received multiple solutions.")
+                
+                if "ID" in config:
+                    qid = config["ID"]
+                    if qid in exam_ids:
+                        raise SyntaxError(f"Received duplicate question ID's {qid}.")
+                else:
+                    qid = rand_id()
+                    while qid in exam_ids:
+                        qid = rand_id()
+
+                exam_ids.add(qid)
 
                 return {
-                    "id": rand_id(),
+                    "id": qid,
                     "type": question_type,
                     "solution": {
                         "solution": solution,

--- a/examtool/examtool/api/convert.py
+++ b/examtool/examtool/api/convert.py
@@ -13,6 +13,7 @@ VERSION = 2  # increment when backward-incompatible changes are made
 html_convert = lambda x: pypandoc.convert_text(x, "html5", "md", ["--mathjax"])
 tex_convert = lambda x: pypandoc.convert_text(x, "latex", "md")
 
+
 class LineBuffer:
     def __init__(self, text):
         self.lines = []
@@ -59,6 +60,7 @@ class LineBuffer:
 
     def location(self):
         return self.i
+
 
 def parse_directive(line):
     if not any(
@@ -488,11 +490,15 @@ def pandoc(target, *, draft=False):
 
 
 def convert(text, *, path=None, draft=False, allow_random_ids=True):
-    return json.loads(convert_str(text, path=path, draft=draft, allow_random_ids=allow_random_ids))
+    return json.loads(
+        convert_str(text, path=path, draft=draft, allow_random_ids=allow_random_ids)
+    )
 
 
 def convert_str(text, *, path=None, draft=False, allow_random_ids=True):
-    return pandoc(_convert(text, path=path, allow_random_ids=allow_random_ids), draft=draft)
+    return pandoc(
+        _convert(text, path=path, allow_random_ids=allow_random_ids), draft=draft
+    )
 
 
 def import_file(filepath: str) -> str:

--- a/examtool/examtool/api/convert.py
+++ b/examtool/examtool/api/convert.py
@@ -558,8 +558,6 @@ class ImportFactory:
         self, buff: LineBuffer, path: str, parentfilepath: str = "main.md"
     ):
         self._handle_imports(buff, path, parentfilepath)
-        b = self.line_map[len(self.line_map) - 1]
-        b.local_start -= 1
         buff.reset()
         return self
 

--- a/examtool/examtool/api/utils.py
+++ b/examtool/examtool/api/utils.py
@@ -33,6 +33,8 @@ class IDFactory:
         self.current_ids = set()
 
     def rand_id(self, length=None):
+        if length is None:
+            length = self.length
         return "".join(random.choices(string.ascii_uppercase, k=length))
 
     def id_from_str(self, string):

--- a/examtool/examtool/api/utils.py
+++ b/examtool/examtool/api/utils.py
@@ -15,16 +15,39 @@ def sanitize_email(email):
     return email.replace("_", r"\_")
 
 
-def rand_id():
-    return "".join(random.choices(string.ascii_uppercase, k=32))
-
-
 def dict_to_list(d):
     out = [None] * len(d)
     for k, v in d.items():
         out[int(k)] = v
     return out
 
-
 def list_to_dict(l):
     return {i: x for i, x in enumerate(l)}
+
+class IDFactory:
+    def __init__(self, id_start="", id_end="", length=32):
+        self.length = length
+        self.id_start = id_start
+        self.id_end = id_end
+        self.current_ids = set()
+
+    def rand_id(self, length=None):
+        return "".join(random.choices(string.ascii_uppercase, k=length))
+
+    def id_from_str(self, string):
+        return self.id_start + string + self.id_end
+
+    def get_id(self, string=None):
+        if string is None:
+            qid = self.rand_id()
+            while qid in self.current_ids:
+                qid = self.rand_id()
+        elif isinstance(string, str):
+            qid = self.id_from_str(string)
+            if qid in self.current_ids:
+                raise SyntaxError(f"Received duplicate question ID's {qid}.")
+        else:
+            raise SyntaxError("ID must be a string or None!")
+
+        self.current_ids.add(qid)
+        return qid

--- a/examtool/examtool/api/utils.py
+++ b/examtool/examtool/api/utils.py
@@ -25,10 +25,11 @@ def list_to_dict(l):
     return {i: x for i, x in enumerate(l)}
 
 class IDFactory:
-    def __init__(self, id_start="", id_end="", length=32):
+    def __init__(self, id_start="", id_end="", length=32, allow_random_ids=True):
         self.length = length
         self.id_start = id_start
         self.id_end = id_end
+        self.allow_random_ids = allow_random_ids
         self.current_ids = set()
 
     def rand_id(self, length=None):
@@ -39,6 +40,8 @@ class IDFactory:
 
     def get_id(self, string=None):
         if string is None:
+            if not self.allow_random_ids:
+                raise SyntaxError("A custom ID is required but was not set for this question!")
             qid = self.rand_id()
             while qid in self.current_ids:
                 qid = self.rand_id()

--- a/examtool/examtool/api/utils.py
+++ b/examtool/examtool/api/utils.py
@@ -21,8 +21,10 @@ def dict_to_list(d):
         out[int(k)] = v
     return out
 
+
 def list_to_dict(l):
     return {i: x for i, x in enumerate(l)}
+
 
 class IDFactory:
     def __init__(self, id_start="", id_end="", length=32, allow_random_ids=True):
@@ -43,7 +45,9 @@ class IDFactory:
     def get_id(self, string=None):
         if string is None:
             if not self.allow_random_ids:
-                raise SyntaxError("A custom ID is required but was not set for this question!")
+                raise SyntaxError(
+                    "A custom ID is required but was not set for this question!"
+                )
             qid = self.rand_id()
             while qid in self.current_ids:
                 qid = self.rand_id()

--- a/examtool/examtool/cli/compile.py
+++ b/examtool/examtool/cli/compile.py
@@ -113,7 +113,12 @@ def compile(
             merged_md.write("\n".join(buff.lines))
             return
         print("Compiling exam...")
-        exam_data = convert(exam_text_data, path=os.path.dirname(md.name), draft=draft, allow_random_ids=allow_random_ids)
+        exam_data = convert(
+            exam_text_data,
+            path=os.path.dirname(md.name),
+            draft=draft,
+            allow_random_ids=allow_random_ids,
+        )
     else:
         print("Fetching exam...")
         exam_data = get_exam(exam=exam)

--- a/examtool/examtool/cli/compile.py
+++ b/examtool/examtool/cli/compile.py
@@ -6,7 +6,7 @@ from json import load, dump
 import click
 from pikepdf import Pdf
 
-from examtool.api.convert import convert, handle_imports, LineBuffer
+from examtool.api.convert import convert, ImportFactory, LineBuffer
 from examtool.api.database import get_exam
 from examtool.api.gen_latex import render_latex
 from examtool.api.utils import sanitize_email
@@ -116,7 +116,7 @@ def compile(
         exam_text_data = md.read()
         if merged_md:
             buff = LineBuffer(exam_text_data)
-            handle_imports(buff, path=os.path.dirname(md.name))
+            ImportFactory().handle_imports(buff, path=os.path.dirname(md.name))
             merged_md.write("\n".join(buff.lines))
             return
         print("Compiling exam...")

--- a/examtool/examtool/cli/compile.py
+++ b/examtool/examtool/cli/compile.py
@@ -124,6 +124,7 @@ def compile(
             exam_text_data,
             path=os.path.dirname(md.name),
             draft=draft,
+            mainfilepath=md.name,
             allow_random_ids=allow_random_ids,
             threadcount=threadcount,
         )

--- a/examtool/examtool/cli/compile.py
+++ b/examtool/examtool/cli/compile.py
@@ -71,6 +71,11 @@ from examtool.cli.utils import (
     default=False,
     help="Generates a draft copy of the exam, which is faster but less accurate.",
 )
+@click.option(
+    "--allow-random-ids/--disallow-random-ids",
+    default=True,
+    help="Raises an error if an ID is not specified by a question in its config.",
+)
 @hidden_output_folder_option
 def compile(
     exam,
@@ -84,6 +89,7 @@ def compile(
     json_out,
     merged_md,
     draft,
+    allow_random_ids,
     out,
 ):
     """
@@ -107,7 +113,7 @@ def compile(
             merged_md.write("\n".join(buff.lines))
             return
         print("Compiling exam...")
-        exam_data = convert(exam_text_data, path=os.path.dirname(md.name), draft=draft)
+        exam_data = convert(exam_text_data, path=os.path.dirname(md.name), draft=draft, allow_random_ids=allow_random_ids)
     else:
         print("Fetching exam...")
         exam_data = get_exam(exam=exam)

--- a/examtool/examtool/cli/compile.py
+++ b/examtool/examtool/cli/compile.py
@@ -76,6 +76,12 @@ from examtool.cli.utils import (
     default=True,
     help="Raises an error if an ID is not specified by a question in its config.",
 )
+@click.option(
+    "--threadcount",
+    default=16,
+    type=int,
+    help="The number of threads to process the json file (Default 16).",
+)
 @hidden_output_folder_option
 def compile(
     exam,
@@ -90,6 +96,7 @@ def compile(
     merged_md,
     draft,
     allow_random_ids,
+    threadcount,
     out,
 ):
     """
@@ -118,6 +125,7 @@ def compile(
             path=os.path.dirname(md.name),
             draft=draft,
             allow_random_ids=allow_random_ids,
+            threadcount=threadcount,
         )
     else:
         print("Fetching exam...")

--- a/examtool/examtool/cli/deploy.py
+++ b/examtool/examtool/cli/deploy.py
@@ -4,7 +4,7 @@ from json import loads
 import click
 from cryptography.fernet import Fernet
 
-from examtool.api.utils import rand_id
+from examtool.api.utils import IDFactory
 from examtool.api.database import process_ok_exam_upload, set_exam, get_exam, set_roster
 from examtool.api.extract_questions import extract_questions, get_name
 from examtool.api.scramble import is_compressible_group, scramble
@@ -67,9 +67,10 @@ def deploy(exam, json, roster, start_time, enable_clarifications):
     print("Exam deployed to https://exam.cs61a.org/{}".format(exam))
 
     print("Initializing announcements...")
+    idf = IDFactory()
     elements = list(extract_questions(exam_content, include_groups=True))
     for element in elements:
-        element["id"] = element.get("id", rand_id())  # add IDs to groups
+        element["id"] = element.get("id", idf.get_id())  # add IDs to groups
     elements = {
         element["id"]: get_name(element)
         for element in elements


### PR DESCRIPTION
The parser will now output the specific location in each file where an error is. For example, if the error was on line 3 of the file test/v010.md, it will output:

`SyntaxError: Parse stopped on line test/v010.md: 3 (M8) with error Unexpected END QUESTIONa in QUESTION`

instead of just the merged file index:

`SyntaxError: Parse stopped on line 8 with error Unexpected END QUESTIONa in QUESTION`