### PR TITLE
Add Lark to code.cs61a.org

### DIFF
--- a/code/src/common/languages.js
+++ b/code/src/common/languages.js
@@ -1,3 +1,4 @@
 export const PYTHON = "PYTHON";
 export const SCHEME = "SCHEME";
 export const SQL = "SQL";
+export const LARK = "LARK";

--- a/code/src/languages/lark/constants/communicationEnums.js
+++ b/code/src/languages/lark/constants/communicationEnums.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const RUN_LARK_CODE = "RUN_LARK_CODE";

--- a/code/src/languages/lark/constants/prompts.js
+++ b/code/src/languages/lark/constants/prompts.js
@@ -1,0 +1,2 @@
+export const PS1 = "lark> ";
+export const PS2 = "....> ";

--- a/code/src/languages/lark/utils/run.js
+++ b/code/src/languages/lark/utils/run.js
@@ -1,0 +1,13 @@
+import { LARK } from "../../../common/languages";
+import { send } from "../../../renderer/utils/communication.js";
+import { RUN_LARK_CODE } from "../constants/communicationEnums.js";
+
+// eslint-disable-next-line import/prefer-default-export
+export function runLarkCode(code, onOutput, onErr, onHalt) {
+  return send(
+    { handler: LARK, type: RUN_LARK_CODE, code },
+    onOutput,
+    onErr,
+    onHalt
+  );
+}

--- a/code/src/languages/lark/utils/test.js
+++ b/code/src/languages/lark/utils/test.js
@@ -1,5 +1,6 @@
 import LarkClient from "../web/larkClient";
 
+// run Lark doctests
 export default function test(code, onSuccess, onError) {
   const client = new LarkClient();
   client

--- a/code/src/languages/lark/utils/test.js
+++ b/code/src/languages/lark/utils/test.js
@@ -1,0 +1,10 @@
+import LarkClient from "../web/larkClient";
+
+export default function test(code, onSuccess, onError) {
+  const client = new LarkClient();
+  client
+    .test(code)
+    .then(onSuccess)
+    .catch((e) => onError(e.toString()));
+  return client.stop;
+}

--- a/code/src/languages/lark/web/communication.js
+++ b/code/src/languages/lark/web/communication.js
@@ -1,8 +1,8 @@
 import { RUN_LARK_CODE } from "../constants/communicationEnums";
 import LarkClient from "./larkClient";
 
-export default async function receive(arg) {
+export default function receive(arg) {
   if (arg.type === RUN_LARK_CODE) {
-    new LarkClient(arg.key, arg.code).start();
+    new LarkClient(arg.key).start(arg.code);
   }
 }

--- a/code/src/languages/lark/web/communication.js
+++ b/code/src/languages/lark/web/communication.js
@@ -1,0 +1,8 @@
+import { RUN_LARK_CODE } from "../constants/communicationEnums";
+import LarkClient from "./larkClient";
+
+export default async function receive(arg) {
+  if (arg.type === RUN_LARK_CODE) {
+    new LarkClient(arg.key, arg.code).start();
+  }
+}

--- a/code/src/languages/lark/web/extractLarkTests.js
+++ b/code/src/languages/lark/web/extractLarkTests.js
@@ -60,7 +60,5 @@ export default function extractLarkTests(text) {
     throw Error(`${DOCTEST_START} block not terminated with ${DOCTEST_END}`);
   }
 
-  console.log(cases);
-
   return { grammar: grammar.join("\n"), cases };
 }

--- a/code/src/languages/lark/web/extractLarkTests.js
+++ b/code/src/languages/lark/web/extractLarkTests.js
@@ -1,0 +1,66 @@
+import { PS1, PS2 } from "../constants/prompts";
+
+const DOCTEST_START = "%doctest";
+const DOCTEST_END = "%end";
+
+export default function extractLarkTests(text) {
+  const lines = text.split("\n");
+  const grammar = [];
+  const cases = [];
+
+  let inDoctest = false;
+  let caseName = null;
+  let currentCase = null;
+  let currentInput = [];
+  let currentOutput = [];
+
+  for (let lineNum = 0; lineNum !== lines.length; ++lineNum) {
+    const line = lines[lineNum];
+    const trimmedLine = line.trimEnd();
+    if (inDoctest) {
+      if (trimmedLine === DOCTEST_END || trimmedLine.startsWith(PS1)) {
+        if (currentInput.length !== 0) {
+          currentCase.push({
+            input: currentInput.join("\n"),
+            output: currentOutput.join("\n"),
+          });
+          currentInput = [];
+          currentOutput = [];
+        }
+        if (trimmedLine === DOCTEST_END) {
+          cases.push({ caseName, tests: currentCase });
+          currentCase = null;
+          inDoctest = false;
+        } else {
+          currentInput.push(line.slice(PS1.length));
+        }
+      } else if (trimmedLine.startsWith(PS2)) {
+        if (currentInput.length === 0 || currentOutput.length !== 0) {
+          throw Error(`Unexpected prompt ${PS2.trim()} on line ${lineNum}`);
+        }
+        currentInput.push(line.slice(PS2.length));
+      } else {
+        if (currentInput.length === 0) {
+          throw Error(
+            `${PS1.trim()} input must be provided before the expected output on line ${lineNum}.`
+          );
+        }
+        currentOutput.push(trimmedLine);
+      }
+    } else if (trimmedLine.startsWith(DOCTEST_START)) {
+      inDoctest = true;
+      caseName = trimmedLine.slice(DOCTEST_START.length).trim();
+      currentCase = [];
+    } else {
+      grammar.push(trimmedLine);
+    }
+  }
+
+  if (inDoctest) {
+    throw Error(`${DOCTEST_START} block not terminated with ${DOCTEST_END}`);
+  }
+
+  console.log(cases);
+
+  return { grammar: grammar.join("\n"), cases };
+}

--- a/code/src/languages/lark/web/larkClient.js
+++ b/code/src/languages/lark/web/larkClient.js
@@ -81,7 +81,7 @@ export default class LarkClient {
         const result = {
           name: [caseName, input],
           rawName: `${caseName} > ${input}`,
-          code: [this.grammar, input],
+          code: [input],
         };
         const { success, error, repr } = await this.larkRun(input);
         if (success) {

--- a/code/src/languages/lark/web/larkClient.js
+++ b/code/src/languages/lark/web/larkClient.js
@@ -3,23 +3,30 @@ import $ from "jquery";
 
 import { registerProcess } from "../../../main/processes";
 import { exit, out, err } from "../../../web/webBackend";
+import { PS1, PS2 } from "../constants/prompts";
+import extractLarkTests from "./extractLarkTests";
 
 export default class LarkClient {
-  PS1 = "lark> ";
-
-  PS2 = "....> ";
-
-  constructor(key, grammar) {
+  constructor(key) {
     this.key = key;
-    this.grammar = grammar;
+    this.grammar = null;
+    this.cases = null;
+
     this.inputQueue = [];
     this.blocked = false;
     this.multiline = false;
     this.multilineInput = [];
     this.treeview = true;
+    this.stopped = false;
   }
 
-  start = async () => {
+  receive = (code) => {
+    const { grammar, cases } = extractLarkTests(code);
+    this.grammar = grammar;
+    this.cases = cases;
+  };
+
+  start = async (code) => {
     registerProcess(this.key, {
       stdin: {
         write: (line) => {
@@ -28,16 +35,79 @@ export default class LarkClient {
         },
       },
       kill: () => {
+        this.stop();
         exit(this.key, "\n\nLark client stopped.");
       },
     });
+
+    try {
+      this.receive(code);
+    } catch (e) {
+      console.error(e);
+      err(this.key, e.toString());
+      exit(this.key, "\n\nLark client stopped.");
+      return;
+    }
+
     const { error } = await this.larkRun();
     if (error) {
       err(this.key, error);
       exit(this.key, "\n\nLark client stopped.");
     } else {
-      err(this.key, this.PS1);
+      err(this.key, PS1);
     }
+  };
+
+  test = async (code) => {
+    this.receive(code);
+    const { error: grammarError } = await this.larkRun();
+    if (grammarError) {
+      throw Error(grammarError);
+    }
+    const results = [];
+    for (let i = 0; i !== this.cases.length; ++i) {
+      const testCase = this.cases[i];
+
+      const caseName =
+        testCase.caseName ||
+        (this.cases.length === 1 ? "Doctests" : `Case ${i + 1}`);
+
+      for (const { input, output } of testCase.tests) {
+        const lines = input.split("\n");
+        const caseCode = [
+          PS1 + lines[0],
+          ...lines.slice(1).map((line) => PS2 + line),
+        ];
+        const result = {
+          name: [caseName, input],
+          rawName: `${caseName} > ${input}`,
+          code: [this.grammar, input],
+        };
+        const { success, error, repr } = await this.larkRun(input);
+        if (success) {
+          result.success = repr.trim() === output.trim();
+          result.raw = (result.success
+            ? [...caseCode, output]
+            : [...caseCode, "Expected:", output, "Received:", repr]
+          ).join("\n");
+        } else {
+          result.success = false;
+          result.raw = [
+            ...caseCode,
+            "Expected:",
+            output,
+            "Received:",
+            error,
+          ].join("\n");
+        }
+        results.push(result);
+      }
+    }
+    return results;
+  };
+
+  stop = () => {
+    this.stopped = true;
   };
 
   run = async () => {
@@ -66,9 +136,9 @@ export default class LarkClient {
       }
 
       if (this.multiline) {
-        err(this.key, this.PS2);
+        err(this.key, PS2);
       } else {
-        err(this.key, this.PS1);
+        err(this.key, PS1);
       }
     }
     this.blocked = false;
@@ -87,12 +157,16 @@ export default class LarkClient {
     }
   };
 
-  larkRun = (text) =>
-    $.post("/api/lark_run", {
+  larkRun = (text) => {
+    if (this.stopped) {
+      return { success: false, error: "The process has stopped." };
+    }
+    return $.post("/api/lark_run", {
       grammar: this.grammar,
       text,
     }).catch((error) => {
       console.error(error);
       return { success: false, error: "An internal error occurred." };
     });
+  };
 }

--- a/code/src/languages/lark/web/larkClient.js
+++ b/code/src/languages/lark/web/larkClient.js
@@ -1,0 +1,66 @@
+import $ from "jquery";
+
+import { registerProcess } from "../../../main/processes";
+import { exit, out, err } from "../../../web/webBackend";
+
+export default class LarkClient {
+  PS1 = "lark> ";
+
+  PS2 = "....> ";
+
+  constructor(key, grammar) {
+    this.key = key;
+    this.grammar = grammar;
+    this.inputQueue = [];
+    this.blocked = false;
+  }
+
+  start = async () => {
+    registerProcess(this.key, {
+      stdin: {
+        write: (line) => {
+          this.inputQueue.push(line);
+          this.run();
+        },
+      },
+      kill: () => {
+        exit(this.key, "\n\nLark client stopped.");
+      },
+    });
+    const { error } = await this.parse();
+    if (error) {
+      err(this.key, error);
+      exit(this.key, "\n\nLark client stopped.");
+    } else {
+      err(this.key, this.PS1);
+    }
+  };
+
+  run = async () => {
+    if (this.blocked) {
+      return;
+    }
+    this.blocked = true;
+    while (this.inputQueue.length > 0) {
+      const line = this.inputQueue.shift();
+      // eslint-disable-next-line no-await-in-loop
+      const { success, error, parsed } = await this.parse(line);
+      if (success) {
+        out(this.key, `DRAW: ${JSON.stringify(["Tree", parsed])}`);
+      } else {
+        err(this.key, error);
+      }
+      err(this.key, this.PS1);
+    }
+    this.blocked = false;
+  };
+
+  parse = (text) =>
+    $.post("/api/lark_run", {
+      grammar: this.grammar,
+      text,
+    }).catch((error) => {
+      console.error(error);
+      return { success: false, error: "An internal error occurred." };
+    });
+}

--- a/code/src/languages/lark/web/larkClient.js
+++ b/code/src/languages/lark/web/larkClient.js
@@ -16,6 +16,7 @@ export default class LarkClient {
     this.blocked = false;
     this.multiline = false;
     this.multilineInput = [];
+    this.treeview = true;
   }
 
   start = async () => {
@@ -57,6 +58,9 @@ export default class LarkClient {
       } else if (line.trim() === ".begin") {
         this.multiline = true;
         this.multilineInput = [];
+      } else if (line.trim() === ".toggleviz") {
+        this.treeview = !this.treeview;
+        out(this.key, `Tree view ${this.treeview ? "enabled" : "disabled"}.\n`);
       } else {
         await this.parse(line.slice(0, line.length - 1));
       }
@@ -71,9 +75,13 @@ export default class LarkClient {
   };
 
   parse = async (text) => {
-    const { success, error, parsed } = await this.larkRun(text);
+    const { success, error, parsed, repr } = await this.larkRun(text);
     if (success) {
-      out(this.key, `DRAW: ${JSON.stringify(["Tree", parsed])}`);
+      if (this.treeview) {
+        out(this.key, `DRAW: ${JSON.stringify(["Tree", parsed])}`);
+      } else {
+        out(this.key, repr);
+      }
     } else {
       err(this.key, error);
     }

--- a/code/src/languages/python/utils/test.js
+++ b/code/src/languages/python/utils/test.js
@@ -1,0 +1,38 @@
+import { DOCTEST_MARKER } from "../../../renderer/components/File";
+import { runPyCode } from "./run";
+
+export default function test(code, onSuccess, onError) {
+  let commandSent = false;
+  const [interactCallback, killCallback, detachCallback] = runPyCode(
+    code,
+    (out) => {
+      if (!out.startsWith(DOCTEST_MARKER)) {
+        return;
+      }
+      const rawData = out.slice(DOCTEST_MARKER.length);
+      // eslint-disable-next-line no-eval
+      const doctestData = (0, eval)(rawData);
+      killCallback();
+      onSuccess(doctestData);
+    },
+    (err) => {
+      if (err.trim() !== ">>>") {
+        // something went wrong in setup
+        killCallback();
+        detachCallback();
+        onError(err.trim());
+        commandSent = true;
+      }
+      if (!commandSent) {
+        commandSent = true;
+        interactCallback("__run_all_doctests()\n");
+      }
+    },
+    () => {}
+  );
+
+  return () => {
+    detachCallback();
+    killCallback();
+  };
+}

--- a/code/src/languages/scheme/utils/test.js
+++ b/code/src/languages/scheme/utils/test.js
@@ -1,0 +1,40 @@
+import { DOCTEST_MARKER } from "../../../renderer/components/File";
+import { runScmCode } from "./run";
+
+const STOP_MARKER = "STOP: ";
+
+export default function test(code, onSuccess, onError) {
+  const doctestData = [];
+  const errors = [];
+  const [, killCallback, detachCallback] = runScmCode(
+    `(define __run_all_doctests 1)\n${code}\n(display "${STOP_MARKER}")`,
+    (out) => {
+      if (out.startsWith(DOCTEST_MARKER)) {
+        const rawData = out.slice(DOCTEST_MARKER.length);
+        // eslint-disable-next-line no-eval
+        const caseData = (0, eval)(`(${rawData})`);
+        doctestData.push(caseData);
+      } else if (out.startsWith(STOP_MARKER)) {
+        killCallback();
+        detachCallback();
+        if (errors.length === 0) {
+          onSuccess(doctestData);
+        } else {
+          onError(errors.join("\n"));
+        }
+      }
+    },
+    (err) => {
+      if (err.trim() !== "scm>") {
+        // something went wrong in setup
+        errors.push(err.trim());
+      }
+    },
+    () => {}
+  );
+
+  return () => {
+    detachCallback();
+    killCallback();
+  };
+}

--- a/code/src/renderer/components/Console.js
+++ b/code/src/renderer/components/Console.js
@@ -74,7 +74,6 @@ export default class Console extends React.Component {
   };
 
   handleInput = (line) => {
-    this.state.interactCallback(line);
     this.setState((state) => {
       const outputData = state.outputData.concat([
         {
@@ -84,6 +83,7 @@ export default class Console extends React.Component {
       ]);
       return { outputData };
     });
+    this.state.interactCallback(line);
   };
 
   render() {

--- a/code/src/renderer/components/Editor.js
+++ b/code/src/renderer/components/Editor.js
@@ -4,18 +4,20 @@ import * as ReactDOM from "react-dom";
 
 import AceEditor from "react-ace";
 
-import "ace-builds/src-noconflict/mode-python";
 import "ace-builds/src-noconflict/ext-language_tools";
 import "ace-builds/src-min-noconflict/ext-searchbox";
 
+import "ace-builds/src-noconflict/mode-python";
 import "ace-builds/src-noconflict/mode-scheme";
 import "ace-builds/src-noconflict/mode-sql";
+import "ace-builds/src-noconflict/mode-cirru";
+
 import "ace-builds/src-noconflict/theme-merbivore_soft";
 
 import firebase from "firebase/app";
 import "firebase/database";
 import firepad from "firepad/dist/firepad.min";
-import { SCHEME } from "../../common/languages";
+import { LARK, SCHEME } from "../../common/languages";
 import { randomString } from "../../common/misc";
 import glWrap from "../utils/glWrap.js";
 
@@ -34,8 +36,6 @@ function Editor({
   const editorRef = useRef();
   const markers = [];
 
-  const [displayLanguage, setDisplayLanguage] = useState(language);
-
   useEffect(() => {
     glContainer.on("show", () => onActivate());
     editorRef.current.editor.focus();
@@ -43,10 +43,6 @@ function Editor({
     onActivate();
     glContainer.on("resize", () => editorRef.current.editor.resize());
   }, []);
-
-  useEffect(() => {
-    setDisplayLanguage(language);
-  }, [language]);
 
   // eslint-disable-next-line consistent-return
   useEffect(() => {
@@ -124,6 +120,8 @@ function Editor({
       });
     }
   }, [language]);
+
+  const displayLanguage = language === LARK ? "CIRRU" : language;
 
   return ReactDOM.createPortal(
     <AceEditor

--- a/code/src/renderer/components/File.js
+++ b/code/src/renderer/components/File.js
@@ -406,7 +406,8 @@ export default class File extends React.Component {
       return SCHEME;
     } else if (
       code.split(": ").length > 1 ||
-      code.split("%ignore").length > 1
+      code.split("%ignore").length > 1 ||
+      code.split("?start").length > 1
     ) {
       return LARK;
     } else {

--- a/code/src/renderer/components/File.js
+++ b/code/src/renderer/components/File.js
@@ -405,7 +405,6 @@ export default class File extends React.Component {
     } else if (code.trim()[0] === "(" || code.split(";").length > 1) {
       return SCHEME;
     } else if (
-      code.split(": ").length > 1 ||
       code.split("%ignore").length > 1 ||
       code.split("?start").length > 1
     ) {

--- a/code/src/renderer/components/File.js
+++ b/code/src/renderer/components/File.js
@@ -423,7 +423,6 @@ export default class File extends React.Component {
   };
 
   handleInput = (line) => {
-    this.state.interactCallback(line);
     this.setState((state) => {
       const outputData = state.outputData.concat([
         {
@@ -433,6 +432,7 @@ export default class File extends React.Component {
       ]);
       return { outputData };
     });
+    this.state.interactCallback(line);
   };
 
   handleEditorChange = (editorText) => {

--- a/code/src/renderer/components/File.js
+++ b/code/src/renderer/components/File.js
@@ -9,7 +9,7 @@ import {
   SHOW_SAVE_DIALOG,
   SHOW_SHARE_DIALOG,
 } from "../../common/communicationEnums.js";
-import { PYTHON, SCHEME, SQL } from "../../common/languages.js";
+import { LARK, PYTHON, SCHEME, SQL } from "../../common/languages.js";
 import {
   Debugger,
   debugPrefix,
@@ -440,7 +440,7 @@ export default class File extends React.Component {
   identifyLanguage = () => {
     const name = this.state.name.toLowerCase();
 
-    const candidates = [PYTHON, SCHEME, SQL];
+    const candidates = [PYTHON, SCHEME, SQL, LARK];
 
     for (const lang of candidates) {
       if (name.endsWith(extension(lang))) {
@@ -455,6 +455,11 @@ export default class File extends React.Component {
       return SQL;
     } else if (code.trim()[0] === "(" || code.split(";").length > 1) {
       return SCHEME;
+    } else if (
+      code.split(": ").length > 1 ||
+      code.split("%ignore").length > 1
+    ) {
+      return LARK;
     } else {
       return PYTHON;
     }
@@ -494,12 +499,14 @@ export default class File extends React.Component {
           onRestart={this.run}
           onInput={this.handleInput}
         />
-        <CurrDebugger
-          ref={this.debugRef}
-          title={`${this.state.name} (Debug)`}
-          data={this.state.debugData}
-          onUpdate={this.handleDebugUpdate}
-        />
+        {CurrDebugger && (
+          <CurrDebugger
+            ref={this.debugRef}
+            title={`${this.state.name} (Debug)`}
+            data={this.state.debugData}
+            onUpdate={this.handleDebugUpdate}
+          />
+        )}
         <OKResults
           ref={this.testRef}
           title={`${this.state.name} (Tests)`}

--- a/code/src/renderer/components/OKResults.js
+++ b/code/src/renderer/components/OKResults.js
@@ -110,14 +110,15 @@ class OKResults extends React.Component {
         rawName: this.state.selectedProblem,
         raw: [""],
         success: true,
+        code: [],
       };
       for (const elem of this.props.data) {
         if (elem.name[0] === this.state.selectedProblem) {
           selectedProblemData.raw.push(elem.raw);
           selectedProblemData.success =
             selectedProblemData.success && elem.success;
+          selectedProblemData.code.push(...elem.code);
         }
-        selectedProblemData.code = elem.code;
       }
       selectedProblemData.raw = selectedProblemData.raw.join(
         `\n${"-".repeat(69)}\n`

--- a/code/src/renderer/components/StdinElem.js
+++ b/code/src/renderer/components/StdinElem.js
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as hljs from "highlight.js";
+import { LARK } from "../../common/languages";
 import {
   getCurrentCursorPosition,
   setCurrentCursorPosition,
@@ -55,7 +56,9 @@ export default class StdinElem extends React.Component {
     const node = this.inputRef.current;
     const cursorPos = getCurrentCursorPosition(node);
     this.inputRef.current.innerText = node.innerText;
-    hljs.highlightBlock(node);
+    if (this.props.lang !== LARK) {
+      hljs.highlightBlock(node);
+    }
     if (cursorPos !== -1) {
       setCurrentCursorPosition(node, cursorPos);
     }

--- a/code/src/renderer/components/StdoutElem.js
+++ b/code/src/renderer/components/StdoutElem.js
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as hljs from "highlight.js";
+import { LARK } from "../../common/languages";
 import { INPUT, ERROR } from "../../common/outputTypes.js";
 
 export default class StdoutElem extends React.PureComponent {
@@ -13,7 +14,7 @@ export default class StdoutElem extends React.PureComponent {
   }
 
   postRender() {
-    if (this.props.type === INPUT) {
+    if (this.props.type === INPUT && this.props.lang !== LARK) {
       hljs.highlightBlock(this.spanRef.current);
     } else if (this.props.type === ERROR) {
       this.spanRef.current.style.color = "palegreen";

--- a/code/src/renderer/components/TestGroup.js
+++ b/code/src/renderer/components/TestGroup.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-array-index-key */
 import React from "react";
 import SuccessIcon from "./SuccessIcon";
 import TestElem from "./TestElem";
@@ -13,9 +14,9 @@ export default class TestGroup extends React.Component {
     const expanded = this.props.name === this.props.selectedProblem;
 
     if (expanded) {
-      children = this.props.children.map((child) => (
+      children = this.props.children.map((child, i) => (
         <TestElem
-          key={child.rawName}
+          key={i}
           name={child.name.slice(1).join(" > ")}
           onClick={() => this.props.onTestClick(child)}
           highlight={child === this.props.selectedTest}

--- a/code/src/renderer/utils/dispatch.js
+++ b/code/src/renderer/utils/dispatch.js
@@ -1,4 +1,5 @@
-import { PYTHON, SCHEME, SQL } from "../../common/languages.js";
+import { LARK, PYTHON, SCHEME, SQL } from "../../common/languages.js";
+import { runLarkCode } from "../../languages/lark/utils/run";
 import pyFormat from "../../languages/python/utils/format.js";
 import scmFormat from "../../languages/scheme/utils/format.js";
 import pyGenerateDebugTrace from "../../languages/python/utils/generateDebugTrace.js";
@@ -38,7 +39,12 @@ const interpreterPool = new ProcessPool(
 );
 
 export function runCode(language) {
-  return interpreterPool.pop(language);
+  switch (language) {
+    case LARK:
+      return runLarkCode;
+    default:
+      return interpreterPool.pop(language);
+  }
 }
 
 export function runFile(language) {
@@ -53,7 +59,6 @@ export function Debugger(language) {
   const options = {
     [PYTHON]: PythonTutorDebug,
     [SCHEME]: SchemeDebugger,
-    [SQL]: SchemeDebugger, // temp!
   };
   return options[language];
 }
@@ -68,9 +73,10 @@ export function debugPrefix(language) {
 
 export function extension(language) {
   const extensions = {
-    PYTHON: ".py",
-    SCHEME: ".scm",
-    SQL: ".sql",
+    [PYTHON]: ".py",
+    [SCHEME]: ".scm",
+    [SQL]: ".sql",
+    [LARK]: ".lark",
   };
   return extensions[language];
 }

--- a/code/src/renderer/utils/dispatch.js
+++ b/code/src/renderer/utils/dispatch.js
@@ -1,4 +1,7 @@
 import { LARK, PYTHON, SCHEME, SQL } from "../../common/languages.js";
+import pyTest from "../../languages/python/utils/test";
+import scmTest from "../../languages/scheme/utils/test";
+import larkTest from "../../languages/lark/utils/test";
 import { runLarkCode } from "../../languages/lark/utils/run";
 import pyFormat from "../../languages/python/utils/format.js";
 import scmFormat from "../../languages/scheme/utils/format.js";
@@ -51,6 +54,15 @@ export function runFile(language) {
   const options = {
     [PYTHON]: runPyFile,
     [SCHEME]: runScmFile,
+  };
+  return options[language];
+}
+
+export function testCode(language) {
+  const options = {
+    [PYTHON]: pyTest,
+    [SCHEME]: scmTest,
+    [LARK]: larkTest,
   };
   return options[language];
 }

--- a/code/src/web-server/language_apis.py
+++ b/code/src/web-server/language_apis.py
@@ -5,7 +5,7 @@ from multiprocessing import Process, Queue
 import black
 import requests
 from flask import jsonify, request
-from lark import Lark, LarkError, Token, Tree
+from lark import Lark, LarkError, Token, Tree, UnexpectedEOF
 
 from IGNORE_scheme_debug import (
     Buffer,
@@ -94,6 +94,13 @@ def create_language_apis(app):
 
         try:
             parse_tree = parser.parse(text)
+        except UnexpectedEOF as e:
+            return jsonify(
+                dict(
+                    error=str(e)
+                    + "[Hint: use the .begin and .end commands to input multiline strings]\n"
+                )
+            )
         except LarkError as e:
             return jsonify(dict(error=str(e)))
 

--- a/code/src/web-server/language_apis.py
+++ b/code/src/web-server/language_apis.py
@@ -83,13 +83,13 @@ def create_language_apis(app):
             grammar += f"""
             %import common.{terminal}
             """
-        text = request.form.get("text", None) or None
+        text = request.form.get("text", None)
         try:
             parser = Lark(grammar, start="start")
         except LarkError as e:
             return jsonify(dict(error=str(e)))
 
-        if not text:
+        if text is None:
             return jsonify(dict(success=True))
 
         try:
@@ -115,7 +115,9 @@ def create_language_apis(app):
             else:
                 return [repr(node)]
 
-        return jsonify(success=True, parsed=export(parse_tree))
+        return jsonify(
+            success=True, parsed=export(parse_tree), repr=parse_tree.pretty()
+        )
 
 
 def scm_worker(code, queue):

--- a/code/src/web-server/requirements.txt
+++ b/code/src/web-server/requirements.txt
@@ -3,4 +3,5 @@ flask
 gunicorn
 braceexpand
 flask-cors
+lark-parser
 -r common/requirements.txt

--- a/code/src/web/webBackend.js
+++ b/code/src/web/webBackend.js
@@ -17,10 +17,11 @@ import {
   SHOW_SHARE_DIALOG,
   START_CONSOLE,
 } from "../common/communicationEnums.js";
-import { PYTHON, SCHEME, SQL } from "../common/languages.js";
+import { LARK, PYTHON, SCHEME, SQL } from "../common/languages.js";
 import python from "../languages/python/web/communication.js";
 import scheme from "../languages/scheme/web/communication.js";
 import sql from "../languages/sql/web/communication.js";
+import lark from "../languages/lark/web/communication.js";
 import { interactProcess, killProcess } from "../main/processes.js";
 import { assignSettingsWatcherKey } from "./settings";
 import showSettingsDialog from "./settingsDialog";
@@ -91,6 +92,8 @@ function receive(arg) {
     scheme(arg);
   } else if (arg.handler === SQL) {
     sql(arg);
+  } else if (arg.handler === LARK) {
+    lark(arg);
   } else {
     console.error(`Unknown handler: ${arg.handler}`);
   }

--- a/code/webpack.web.config.js
+++ b/code/webpack.web.config.js
@@ -79,11 +79,7 @@ module.exports = (env) => ({
       ELECTRON: false,
       SCHEME_COMPILE: (env && env.SCHEME_COMPILE) || false,
       __static: JSON.stringify("/static"),
-      VERSION: '"2.4.3"',
-    }),
-    new MonacoWebpackPlugin({
-      output: "./static",
-      languages: ["python", "scheme", "sql"],
+      VERSION: '"2.6.0"',
     }),
     new webpack.ProvidePlugin({
       $: "jquery",


### PR DESCRIPTION
- [x] Whitelist imports, don't ban them
- [x] `.begin`, .`end` for multiline
- [x] Some sort of doctests (`%expect`?)


Features:
- Server-side Lark interpreter that runs `.lark` files or autodetected (basically if they contain`?start`)
- Multi-line input like:
![image](https://user-images.githubusercontent.com/18374604/115111953-e0e42d80-9f37-11eb-987e-0fbe5e3429fc.png)
- Imports from `common` are supported
- Doctests work like this:
```
%doctest
lark> (+ 1 2
....> )
calc_op
  (
  +
  operand	1
  operand	2
  )
lark> (+ 1 2)
calc_op
  (
  +
  operand	8
  operand	2
  )
%end
```
put anywhere in a grammar. Multiple doctest blocks can be included. To give them names, write `%doctest <NAME>`.

To get the expected output in a console, run `.toggleviz` to disable tree output:
![image](https://user-images.githubusercontent.com/18374604/115112008-20ab1500-9f38-11eb-8c8b-68f6c074f6d0.png)

In the doctest pane, clicking the debug icon will display a tree representation of the actual output (or outputs, if you debug an entire test case), and drop you into a lark> console:
![image](https://user-images.githubusercontent.com/18374604/115112045-5cde7580-9f38-11eb-9102-27fa118c7b36.png)
