### PR TITLE
Sections tool: add optional enrollment codes

### DIFF
--- a/sections/.vscode/settings.json
+++ b/sections/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/local/bin/python3.7"
+}

--- a/sections/.vscode/settings.json
+++ b/sections/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/usr/local/bin/python3.7"
-}

--- a/sections/server/models.py
+++ b/sections/server/models.py
@@ -56,6 +56,10 @@ class Section(db.Model):
     @tags.setter
     def tags(self, tags: List[str]):
         self.tag_string = ",".join(tags)
+    
+    @property
+    def needs_enrollment_code(self):
+        return self.enrollment_code not in ["", None]
 
     @property
     def json(self):
@@ -71,7 +75,7 @@ class Section(db.Model):
             "startTime": self.start_time,
             "endTime": self.end_time,
             "callLink": self.call_link,
-            "needsEnrollmentCode": bool(self.enrollment_code),
+            "needsEnrollmentCode": self.needs_enrollment_code,
             "tags": self.tags,
         }
 

--- a/sections/server/models.py
+++ b/sections/server/models.py
@@ -56,7 +56,7 @@ class Section(db.Model):
     @tags.setter
     def tags(self, tags: List[str]):
         self.tag_string = ",".join(tags)
-    
+
     @property
     def needs_enrollment_code(self):
         return self.enrollment_code not in ["", None]

--- a/sections/server/models.py
+++ b/sections/server/models.py
@@ -34,6 +34,7 @@ class Section(db.Model):
     end_time: int = db.Column(db.Integer)
     capacity: int = db.Column(db.Integer)
     call_link: str = db.Column(db.String(255), nullable=True)
+    enrollment_code: str = db.Column(db.String(255), nullable=True)
     staff_id: int = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
     staff: "User" = db.relationship(
         "User", backref=db.backref("sections_taught", lazy="joined"), lazy="joined"
@@ -70,6 +71,7 @@ class Section(db.Model):
             "startTime": self.start_time,
             "endTime": self.end_time,
             "callLink": self.call_link,
+            "needsEnrollmentCode": bool(self.enrollment_code),
             "tags": self.tags,
         }
 

--- a/sections/server/state.py
+++ b/sections/server/state.py
@@ -162,7 +162,7 @@ def create_state_client(app: flask.Flask):
         target_section: Section = Section.query.get(target_section_id)
         if target_section.capacity <= len(target_section.students):
             raise Failure("Target tutorial section is already full.")
-        if (target_section.enrollment_code or "") != enrollment_code:
+        if target_section.needs_enrollment_code and enrollment_code != target_section.enrollment_code:
             raise Failure("Invalid enrollment code; cannot join section.")
         # remove them from *all* old_sections for now
         current_user.sections = [target_section]

--- a/sections/server/state.py
+++ b/sections/server/state.py
@@ -146,8 +146,15 @@ def create_state_client(app: flask.Flask):
         return section.full_json
 
     @api
+    @staff_required
+    def get_enrollment_code(section_id: Union[int, str]):
+        section_id = int(section_id)
+        section: Section = Section.query.get(section_id)
+        return section.enrollment_code
+
+    @api
     @login_required
-    def join_section(target_section_id: str):
+    def join_section(target_section_id: str, enrollment_code: str = ""):
         if not get_config().can_students_change:
             raise Failure("Students cannot add themselves themselves to sections!")
         target_section_id = int(target_section_id)
@@ -155,6 +162,8 @@ def create_state_client(app: flask.Flask):
         target_section: Section = Section.query.get(target_section_id)
         if target_section.capacity <= len(target_section.students):
             raise Failure("Target tutorial section is already full.")
+        if (target_section.enrollment_code or "") != enrollment_code:
+            raise Failure("Invalid enrollment code; cannot join section.")
         # remove them from *all* old_sections for now
         current_user.sections = [target_section]
         db.session.commit()
@@ -217,6 +226,15 @@ def create_state_client(app: flask.Flask):
         section_id = int(section_id)
         section = Section.query.get(section_id)
         section.call_link = call_link
+        db.session.commit()
+        return refresh_state()
+
+    @api
+    @staff_required
+    def update_section_enrollment_code(section_id: str, enrollment_code: str):
+        section_id = int(section_id)
+        section = Section.query.get(section_id)
+        section.enrollment_code = enrollment_code
         db.session.commit()
         return refresh_state()
 

--- a/sections/server/state.py
+++ b/sections/server/state.py
@@ -162,7 +162,10 @@ def create_state_client(app: flask.Flask):
         target_section: Section = Section.query.get(target_section_id)
         if target_section.capacity <= len(target_section.students):
             raise Failure("Target tutorial section is already full.")
-        if target_section.needs_enrollment_code and enrollment_code != target_section.enrollment_code:
+        if (
+            target_section.needs_enrollment_code
+            and enrollment_code != target_section.enrollment_code
+        ):
             raise Failure("Invalid enrollment code; cannot join section.")
         # remove them from *all* old_sections for now
         current_user.sections = [target_section]

--- a/sections/src/EnrolledSectionCard.js
+++ b/sections/src/EnrolledSectionCard.js
@@ -13,7 +13,6 @@ import StateContext from "./StateContext";
 import Tags from "./Tags";
 import useStateAPI from "./useStateAPI";
 import useAPI from "./useAPI";
-import useSectionAPI from "./useSectionAPI";
 
 type Props = {
   section: Section,
@@ -81,10 +80,9 @@ export default function EnrolledSectionCard({ section }: Props) {
 
   const [description, setDescription] = useState(section.description ?? "");
   const [callLink, setCallLink] = useState(section.callLink ?? "");
-  const [enrollmentCode, setEnrollmentCode] = useState("");
-  const [currentEnrollmentCode, setCurrentEnrollmentCode] = useState("");
+  const [enrollmentCode, setEnrollmentCode] = useState(""); // in the text field
+  const [currentEnrollmentCode, setCurrentEnrollmentCode] = useState(""); // in the db
 
-  console.log(JSON.stringify(section));
   return (
     <Card>
       <Card.Header>

--- a/sections/src/EnrolledSectionCard.js
+++ b/sections/src/EnrolledSectionCard.js
@@ -12,7 +12,7 @@ import type { Section, EnrollmentCode } from "./models";
 import StateContext from "./StateContext";
 import Tags from "./Tags";
 import useStateAPI from "./useStateAPI";
-import useAPI from './useAPI';
+import useAPI from "./useAPI";
 import useSectionAPI from "./useSectionAPI";
 
 type Props = {
@@ -48,7 +48,7 @@ function sentenceList(items: Array<React.MixedElement>, isStaff: ?boolean) {
   }
 }
 
-export default function EnrolledSectionCard({section}: Props) {
+export default function EnrolledSectionCard({ section }: Props) {
   const nextText = `The next session takes place ${nextSessionStartTime(
     section
   ).fromNow()}.`;
@@ -61,20 +61,23 @@ export default function EnrolledSectionCard({section}: Props) {
   const leaveSection = useStateAPI("leave_section");
   const updateSectionDescription = useStateAPI("update_section_description");
   const updateSectionCallLink = useStateAPI("update_section_call_link");
-  const updateSectionEnrollmentCode = useStateAPI("update_section_enrollment_code", () => getEnrollmentCode({section_id: section.id}));
-  const getEnrollmentCode =
-    useAPI("get_enrollment_code",
-      (code: EnrollmentCode) => {
-        setEnrollmentCode(code);
-        setCurrentEnrollmentCode(code);
-      }
+  const updateSectionEnrollmentCode = useStateAPI(
+    "update_section_enrollment_code",
+    () => getEnrollmentCode({ section_id: section.id })
+  );
+  const getEnrollmentCode = useAPI(
+    "get_enrollment_code",
+    (code: EnrollmentCode) => {
+      setEnrollmentCode(code);
+      setCurrentEnrollmentCode(code);
+    }
   );
 
   useEffect(() => {
     if (isStaff) {
-      getEnrollmentCode({section_id: section.id});
+      getEnrollmentCode({ section_id: section.id });
     }
-  }, [])
+  }, []);
 
   const [description, setDescription] = useState(section.description ?? "");
   const [callLink, setCallLink] = useState(section.callLink ?? "");
@@ -164,12 +167,11 @@ export default function EnrolledSectionCard({section}: Props) {
                 <Button
                   size="sm"
                   onClick={() => {
-                      updateSectionEnrollmentCode({
-                        section_id: section.id,
-                        enrollment_code: enrollmentCode,
-                      })
-                    }
-                  }
+                    updateSectionEnrollmentCode({
+                      section_id: section.id,
+                      enrollment_code: enrollmentCode,
+                    });
+                  }}
                 >
                   Submit
                 </Button>

--- a/sections/src/EnterEnrollmentCodeModal.js
+++ b/sections/src/EnterEnrollmentCodeModal.js
@@ -1,0 +1,36 @@
+// @flow strict
+
+import * as React from "react";
+import Button from "react-bootstrap/Button";
+import Modal from "react-bootstrap/Modal";
+import FormControl from "react-bootstrap/FormControl";
+import { useState } from "react";
+
+
+type Props = {
+  show: Boolean,
+  onClose: () => void,
+};
+
+export default function AddEnrollmentCodeModal({ show, onClose }: Props) {
+  const [enrollmentCode, setEnrollmentCode] = useState("");
+
+  return (
+    <Modal show={show} onHide={() => onClose(enrollmentCode)}>
+      <Modal.Header closeButton>
+        <Modal.Title>Enter Enrollment Code</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+      <FormControl
+        value={enrollmentCode ?? ""}
+        onChange={(e) => setEnrollmentCode(e.target.value)}
+        />
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="success" onClick={() => onClose(enrollmentCode)}>
+          Submit
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/sections/src/EnterEnrollmentCodeModal.js
+++ b/sections/src/EnterEnrollmentCodeModal.js
@@ -13,7 +13,7 @@ type Props = {
   onClose: (code: EnrollmentCode) => void,
 };
 
-export default function AddEnrollmentCodeModal({ show, onClose }: Props) {
+export default function EnterEnrollmentCodeModal({ show, onClose }: Props) {
   const [enrollmentCode, setEnrollmentCode] = useState("");
 
   return (

--- a/sections/src/EnterEnrollmentCodeModal.js
+++ b/sections/src/EnterEnrollmentCodeModal.js
@@ -6,9 +6,11 @@ import Modal from "react-bootstrap/Modal";
 import FormControl from "react-bootstrap/FormControl";
 import { useState } from "react";
 
+import type { EnrollmentCode } from "./models";
+
 type Props = {
   show: Boolean,
-  onClose: () => void,
+  onClose: (code: EnrollmentCode) => void,
 };
 
 export default function AddEnrollmentCodeModal({ show, onClose }: Props) {

--- a/sections/src/EnterEnrollmentCodeModal.js
+++ b/sections/src/EnterEnrollmentCodeModal.js
@@ -6,7 +6,6 @@ import Modal from "react-bootstrap/Modal";
 import FormControl from "react-bootstrap/FormControl";
 import { useState } from "react";
 
-
 type Props = {
   show: Boolean,
   onClose: () => void,
@@ -21,9 +20,9 @@ export default function AddEnrollmentCodeModal({ show, onClose }: Props) {
         <Modal.Title>Enter Enrollment Code</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-      <FormControl
-        value={enrollmentCode ?? ""}
-        onChange={(e) => setEnrollmentCode(e.target.value)}
+        <FormControl
+          value={enrollmentCode ?? ""}
+          onChange={(e) => setEnrollmentCode(e.target.value)}
         />
       </Modal.Body>
       <Modal.Footer>

--- a/sections/src/StudentSectionCard.js
+++ b/sections/src/StudentSectionCard.js
@@ -5,7 +5,6 @@ import { useContext, useState } from "react";
 import * as React from "react";
 import Button from "react-bootstrap/Button";
 
-
 import Card from "react-bootstrap/Card";
 import ListGroup from "react-bootstrap/ListGroup";
 import { Link } from "react-router-dom";
@@ -47,79 +46,93 @@ export default function StudentSectionCard({
     if (section.needsEnrollmentCode) {
       setEnrolling(true);
     } else {
-      joinSection({ target_section_id: section.id })
+      joinSection({ target_section_id: section.id });
     }
-  }
+  };
 
   const onEnrollmentCodeEntered = (enrollmentCode) => {
-      setEnrolling(false);
-      joinSection({ target_section_id: section.id, enrollment_code: enrollmentCode });
-  }
+    setEnrolling(false);
+    joinSection({
+      target_section_id: section.id,
+      enrollment_code: enrollmentCode,
+    });
+  };
 
   return (
     <>
-    <Card
-      border={enrolledInThisSection || teachingThisSection ? "primary" : null}
-    >
-      <Card.Body>
-        <Card.Title>
-          {isStaff &&
-            (section.staff == null
-              ? config.canTutorsChange && (
-                  <Button
-                    className="float-right"
-                    size="sm"
-                    onClick={() => claimSection({ section_id: section.id })}
-                  >
-                    Claim
-                  </Button>
-                )
-              : (section.staff.email === currentUser?.email
-                  ? config.canTutorsChange
-                  : config.canTutorsReassign) && (
-                  <Button
-                    className="float-right"
-                    size="sm"
-                    variant="danger"
-                    onClick={() => unassignSection({ section_id: section.id })}
-                  >
-                    Unassign
-                  </Button>
-                ))}
-          {!isStaff && <Tags tags={section.tags} />}
-          {isStaff ? <Link to={`/section/${section.id}`}>{title}</Link> : title}
-        </Card.Title>
-        <Card.Text>{section.description}</Card.Text>
-      </Card.Body>
-      <ListGroup variant="flush">
-        {section.students.map((student, i) => (
-          <ListGroup.Item key={i} active={student.email === currentUser?.email}>
-            {enrolledInThisSection || isStaff ? student.name : "A student"}
-          </ListGroup.Item>
-        ))}
-        {hasSpace && !isStaff && config.canStudentsChange ? (
-          <ListGroup.Item
-            disabled={enrolledInThisSection}
-            action={!enrolledInThisSection}
-            onClick={joinSectionWorkflow}
-          >
-            {enrolledInThisSection ? (
-              <div>Switch to Section {slotText}</div>
+      <Card
+        border={enrolledInThisSection || teachingThisSection ? "primary" : null}
+      >
+        <Card.Body>
+          <Card.Title>
+            {isStaff &&
+              (section.staff == null
+                ? config.canTutorsChange && (
+                    <Button
+                      className="float-right"
+                      size="sm"
+                      onClick={() => claimSection({ section_id: section.id })}
+                    >
+                      Claim
+                    </Button>
+                  )
+                : (section.staff.email === currentUser?.email
+                    ? config.canTutorsChange
+                    : config.canTutorsReassign) && (
+                    <Button
+                      className="float-right"
+                      size="sm"
+                      variant="danger"
+                      onClick={() =>
+                        unassignSection({ section_id: section.id })
+                      }
+                    >
+                      Unassign
+                    </Button>
+                  ))}
+            {!isStaff && <Tags tags={section.tags} />}
+            {isStaff ? (
+              <Link to={`/section/${section.id}`}>{title}</Link>
             ) : (
-              <span className="btn-link">
-                {enrolledSection == null ? "Join Section" : "Switch to Section"}{" "}
-                {slotText}
-              </span>
+              title
             )}
-          </ListGroup.Item>
-        ) : null}
-      </ListGroup>
-    </Card>
-    <EnterEnrollmentCodeModal
-      show={enrolling}
-      section={section}
-      onClose={onEnrollmentCodeEntered}
-    />
-  </>
+          </Card.Title>
+          <Card.Text>{section.description}</Card.Text>
+        </Card.Body>
+        <ListGroup variant="flush">
+          {section.students.map((student, i) => (
+            <ListGroup.Item
+              key={i}
+              active={student.email === currentUser?.email}
+            >
+              {enrolledInThisSection || isStaff ? student.name : "A student"}
+            </ListGroup.Item>
+          ))}
+          {hasSpace && !isStaff && config.canStudentsChange ? (
+            <ListGroup.Item
+              disabled={enrolledInThisSection}
+              action={!enrolledInThisSection}
+              onClick={joinSectionWorkflow}
+            >
+              {enrolledInThisSection ? (
+                <div>Switch to Section {slotText}</div>
+              ) : (
+                <span className="btn-link">
+                  {enrolledSection == null
+                    ? "Join Section"
+                    : "Switch to Section"}{" "}
+                  {slotText}
+                </span>
+              )}
+            </ListGroup.Item>
+          ) : null}
+        </ListGroup>
+      </Card>
+      <EnterEnrollmentCodeModal
+        show={enrolling}
+        section={section}
+        onClose={onEnrollmentCodeEntered}
+      />
+    </>
   );
 }

--- a/sections/src/models.js
+++ b/sections/src/models.js
@@ -5,6 +5,7 @@ import * as React from "react";
 
 export type ID = string;
 export type Time = number;
+export type EnrollmentCode = string;
 
 export type Person = {
   id: ID,


### PR DESCRIPTION
staff should be able to configure an enrollment code for CS scholar sections, per @itsvs 

staff side:

![staff side enrollment code](https://user-images.githubusercontent.com/25068150/119932282-f4c87980-bf50-11eb-84a9-b7e947c3b3d3.gif)

student side:

![student side enrollment code](https://user-images.githubusercontent.com/25068150/119932292-f7c36a00-bf50-11eb-8b66-4af7d2af9d2e.gif)

if the colors look weird, its probably the gif compression's fault