### PR TITLE
rollback(ide): disable shared bt cache

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -21,6 +21,6 @@ COPY . ./
 
 RUN pip install -r requirements.txt
 
-ENV BUILDTOOL_CACHE_DIRECTORY /save/.cache
+# ENV BUILDTOOL_CACHE_DIRECTORY /save/.cache
 
 CMD python main.py


### PR DESCRIPTION
Disables the shared buildtool cache until permission errors can be properly sorted﻿
