### PR TITLE
fix(sections): show section day in correct tz

### DIFF
--- a/sections/src/models.js
+++ b/sections/src/models.js
@@ -122,7 +122,9 @@ export function sessionStartTimes(section: Section) {
 
 export function sectionInterval(section: Section): React.MixedElement {
   const isPT = moment.tz.guess() === TZ;
-  const firstSectionStartTime = moment.unix(section.startTime).tz(moment.tz.guess());
+  const firstSectionStartTime = moment
+    .unix(section.startTime)
+    .tz(moment.tz.guess());
   const startTime = nextSessionStartTime(section);
   const endTime = startTime
     .clone()

--- a/sections/src/models.js
+++ b/sections/src/models.js
@@ -122,7 +122,7 @@ export function sessionStartTimes(section: Section) {
 
 export function sectionInterval(section: Section): React.MixedElement {
   const isPT = moment.tz.guess() === TZ;
-  const firstSectionStartTime = moment.unix(section.startTime).tz(TZ);
+  const firstSectionStartTime = moment.unix(section.startTime).tz(moment.tz.guess());
   const startTime = nextSessionStartTime(section);
   const endTime = startTime
     .clone()


### PR DESCRIPTION
Fixes the bug introduced in the previous PR, whereby section times were in the correct timezone but section days were in PT.﻿
