### PR TITLE
[WIP] OH email config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.env/
 env/
 venv/
 build/*

--- a/oh/oh_queue/reminders.py
+++ b/oh/oh_queue/reminders.py
@@ -9,7 +9,7 @@ from common.course_config import format_coursecode, get_course
 from oh_queue.models import AppointmentSignup
 
 
-def send_appointment_reminder(signup: AppointmentSignup):
+def send_appointment_reminder(signup: AppointmentSignup, course_email: str):
     appointment = signup.appointment
     user = signup.user
 
@@ -26,7 +26,7 @@ def send_appointment_reminder(signup: AppointmentSignup):
     )
 
     send_email(
-        sender="OH Queue <cs61a@berkeley.edu>",
+        sender=f"OH Queue <{course_email}>",
         target=user.email,
         subject=f"{format_coursecode(get_course())} Appointment Scheduled",
         body=(
@@ -39,7 +39,7 @@ def send_appointment_reminder(signup: AppointmentSignup):
     To edit or cancel this appointment, go to https://{get_domain()}.
 
     Best,
-    The 61A Software Team
+    The {format_coursecode(get_course())} Software Team
     """.strip()
         ),
         attachments={"invite.ics": b64encode(str(c).encode("utf-8")).decode("ascii")},

--- a/oh/oh_queue/static/js/components/admin_config_manager.js
+++ b/oh/oh_queue/static/js/components/admin_config_manager.js
@@ -55,6 +55,19 @@ function AdminConfigManager({ state: { config } }) {
                 />
               </td>
             </tr>
+            <tr>
+              <td>
+                <p>
+                  When an email is sent from the course, what should the email be? (berkeley.edu email)
+                </p>
+              </td>
+              <td className="col-md-3">
+                <ConfigLinkedText
+                  config={config}
+                  configKey="course_email"
+                />
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/oh/oh_queue/views.py
+++ b/oh/oh_queue/views.py
@@ -471,6 +471,14 @@ def init_config():
             course=get_course(),
         )
     )
+    db.session.add(
+        ConfigEntry(
+            key="course_email",
+            value="cs61a@berkeley.edu",
+            public=True,
+            course=get_course(),
+        )
+    )
     db.session.commit()
 
 
@@ -1351,6 +1359,13 @@ def assign_appointment(data):
     ):
         return socket_error("Appointment is at full capacity")
 
+    course_email = ConfigEntry.query.filter_by(
+        key="weekly_appointment_limit", 
+        course=get_course()).one_or_none().value
+    
+    if course_email is None:
+        course_email = "cs61a@berkeley.edu"
+
     signup = AppointmentSignup(
         appointment_id=data["appointment_id"],
         user_id=user_id,
@@ -1360,10 +1375,11 @@ def assign_appointment(data):
         attendance_status=old_attendance,
         course=get_course(),
     )
+
     db.session.add(signup)
     db.session.commit()
 
-    send_appointment_reminder(signup)
+    send_appointment_reminder(signup, course_email)
 
     emit_appointment_event(appointment, "student_assigned")
 


### PR DESCRIPTION
Allows for a course like CS 70 to send their appointment emails from an email of their choice rather than cs61a@berkeley.edu